### PR TITLE
Composer: allow PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": "~5.3",
+		"php": ">=5.3",
 		"nette/application": "~2.2"
 	},
 	"require-dev": {


### PR DESCRIPTION
Is there any reason for this limit?